### PR TITLE
[SUGGESTED] Decrease deacceleration

### DIFF
--- a/src/game/chopper.js
+++ b/src/game/chopper.js
@@ -65,7 +65,7 @@ export default ex.Actor.extend({
     const powerModifier = this.y / 50;
     this.powerModifier = powerModifier;
     if (!this.animatingUpwards) {
-      this.unclampedVelocity = this.vel.y + (Settings.ACCELERATION / 60);
+      this.unclampedVelocity = this.vel.y + (Settings.ACCELERATION / 100 );
       this.vel.y = ex.Util.clamp(
         this.unclampedVelocity,
         -Settings.MAX_VELOCITY,


### PR DESCRIPTION
Suggested decrease in the deacceleration / downwards velocity when player input doesn't generate enough power.

This should give a player a slightly increased timeframe and chance to turn their chopper around from crashing.

This number is entirely chosen by testing what looks and feels good. Open for comments.